### PR TITLE
Dev 267 & 269

### DIFF
--- a/assets/js/celebrations.js
+++ b/assets/js/celebrations.js
@@ -72,17 +72,17 @@ const markup = `
 
 <div class="card">
 
-    <div class="card-cover">
+    <span class="card-cover">
      “
-    </div>
+    </span>
 
-    <div class="avatar">
+    <span class="avatar">
         <img class="avatar-image" src= ${pickedUser.image} />
-    </div>
+    </span>
 
-    <div class="card-content">
+    <p class="card-content">
         ${pickedUser.celebration}
-    </div>
+    </p>
 
     <p class='card-text'> - ${pickedUser.fName} ${pickedUser.lName}</p>
 </div>

--- a/index.html
+++ b/index.html
@@ -127,7 +127,7 @@
           <div class="project-image">
             <img
               src="./assets/images/website-images/hacktoberfest.png"
-              alt="Hacktoberfest challenge logo | a pink letter H on a navy blue background"
+              alt="Hacktoberfest 2020 logo | pink H on blue background"
               onclick="openHacktoberfest2020Challenge()"
             />
           </div>


### PR DESCRIPTION
Fixed the Celebrations HTML code to utilize <p> tag for text and display internal <div> as a <span> instead for more accessible formatting.  Also edited the Alt tag for the Hacktoberfest image under projects so that it doesn't wrap hopefully.  Not sure how the image for the Ticket was obtained and what screensize. May need to adjust that alt tag again to something shorter if it still continues to wrap due to length.